### PR TITLE
fix: Logout example improvements

### DIFF
--- a/src/main/java/com/vaadin/tutorial/crm/security/SecurityUtils.java
+++ b/src/main/java/com/vaadin/tutorial/crm/security/SecurityUtils.java
@@ -25,11 +25,10 @@ public final class SecurityUtils {
     }
 
     public void logout() {
+        UI.getCurrent().getPage().setLocation(LOGOUT_SUCCESS_URL);
         SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();
-        logoutHandler.setInvalidateHttpSession(false);
         logoutHandler.logout(
                 VaadinServletRequest.getCurrent().getHttpServletRequest(), null,
                 null);
-        UI.getCurrent().getPage().setLocation(LOGOUT_SUCCESS_URL);
     }
 }


### PR DESCRIPTION
Current example code doesn't invalidate the session, which is usually desired.
This fix invalidates the session and redirects to logout page.