### PR TITLE
fix: Redirect to logout page before handle logout

### DIFF
--- a/src/main/java/com/example/application/security/SecurityService.java
+++ b/src/main/java/com/example/application/security/SecurityService.java
@@ -24,10 +24,10 @@ public class SecurityService {
     }
 
     public void logout() {
+        UI.getCurrent().getPage().setLocation(LOGOUT_SUCCESS_URL);
         SecurityContextLogoutHandler logoutHandler = new SecurityContextLogoutHandler();
         logoutHandler.logout(
                 VaadinServletRequest.getCurrent().getHttpServletRequest(), null,
                 null);
-        UI.getCurrent().getPage().setLocation(LOGOUT_SUCCESS_URL);
     }
 }


### PR DESCRIPTION
## Description

Handle logout after redirecting, because otherwise UI.getCurrent would be nulled.
Aligns the codes with examples in documentation.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
